### PR TITLE
Fix check for passing both onestep and iterated

### DIFF
--- a/pydynpd/command.py
+++ b/pydynpd/command.py
@@ -233,6 +233,10 @@ class command(object):
 
         # possible_options=[{'onestep', 'iterated'},'nolevel', 'timedumm', 'collapse']
 
+        if "onestep" in list_options and "iterated" in list_options:
+            print("One-step and iterative estimations are mutually exclusive")
+            exit()
+
         for option in list_options:
             if option == 'onestep':
                 options.steps = 1
@@ -251,10 +255,6 @@ class command(object):
             else:
                 print(option + ' is not an option allowed')
                 exit()
-
-        if options.steps == 1 and options.steps == 1000:
-            print("One-step and iterative estimations are mutually exclusive")
-            exit()
 
         return (options)
 


### PR DESCRIPTION
Previously, the check for "onestep" and "iterated" both being passed would never actually return `True`, because if "onestep" and "iterated" were both passed, `options.steps` would be set to 1 or 1000 depending on which was passed last, as it would overwrite `options.steps`.

The line `options.steps == 1 and options.steps == 1000` can never return `True` in python.

Now, the logic is to check if both words are present in the input.